### PR TITLE
remove dependency to django-rest-framework

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -42,7 +42,6 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'register',
-    'rest_framework',
 ]
 
 MIDDLEWARE = [

--- a/register/models.py
+++ b/register/models.py
@@ -4,7 +4,7 @@ from django.contrib.auth import models as admin_models
 from django.core.exceptions import ValidationError
 from django.db import models
 from register.emails import sendgrid_send
-from rest_framework.reverse import reverse
+from register.utils import reverse
 
 status = [
     ('A', 'Accepted'),

--- a/register/utils.py
+++ b/register/utils.py
@@ -1,0 +1,15 @@
+from django.urls import reverse as django_reverse
+
+
+def reverse(viewname, args=None, kwargs=None, request=None, format=None, **extra):
+    """
+    Same as `django.urls.reverse`, but optionally takes a request
+    and returns a fully qualified URL, using the request to get the base URL.
+    """
+    if format is not None:
+        kwargs = kwargs or {}
+        kwargs['format'] = format
+    url = django_reverse(viewname, args=args, kwargs=kwargs, **extra)
+    if request:
+        return request.build_absolute_uri(url)
+    return url

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Django==1.10.4
 django-filter==1.0.1
-djangorestframework==3.5.3
 Markdown==2.6.7
 python-http-client==2.2.1
 requests==2.12.3


### PR DESCRIPTION
Django Rest Framework was an initial dependency to this project.

Now we solved what we wanted with the admin views, so we remove the dependency to keep the project more "lightweight"