### PR TITLE
Fix bug when canceling attendance

### DIFF
--- a/register/emails.py
+++ b/register/emails.py
@@ -30,6 +30,24 @@ class MailListManager:
     def __init__(self):
         self.sg = sendgrid.SendGridAPIClient(apikey=settings.SENDGRID_API_KEY)
 
+    def _create_sendgrid_recipient(self, application):
+        recipient = [
+            {
+                "application_id": application.id,
+                "email": application.email,
+                "first_name": application.name,
+                "last_name": application.lastname,
+            }
+        ]
+        response = self.sg.client.contactdb.recipients.post(request_body=recipient)
+        body = json.loads(response.body.decode('utf-8'))
+        if response.status_code != 201 or len(body["persisted_recipients"]) != 1:
+            error('Could not create a recipient for the applicant {} ({}). '
+                  'SendGrid API responded with status code {}.'
+                  .format(application.id, application.name, response.status_code))
+        created_id = body["persisted_recipients"][0]
+        return created_id
+
     def _add_recipient_to_list(self, recipient_id, list_id):
         response = self.sg.client.contactdb.lists._(list_id).recipients._(recipient_id).post()
         if response.status_code != 201:
@@ -43,37 +61,34 @@ class MailListManager:
 
         else:
             # If it doesn't, create recipient on sendgrid and store its id
-            recipient = [
-                {
-                    "application_id": application.id,
-                    "email": application.email,
-                    "first_name": application.name,
-                    "last_name": application.lastname,
-                }
-            ]
-            response = self.sg.client.contactdb.recipients.post(request_body=recipient)
-            body = json.loads(response.body.decode('utf-8'))
-
-            if response.status_code != 201 or len(body["persisted_recipients"]) != 1:
-                error('Could not create a recipient for the applicant {} ({}). '
-                      'SendGrid API responded with status code {}.'
-                      .format(application.id, application.name, response.status_code))
-
-            recipient_id = body["persisted_recipients"][0]
+            recipient_id = self._create_sendgrid_recipient(application)
             application.sendgrid_id = recipient_id
             application.save()
 
         # Add recipient to list
         self._add_recipient_to_list(recipient_id, list_id)
 
-    def remove_recipient_from_list(self, recipient_id, list_id):
+    def _remove_recipient_from_list(self, recipient_id, list_id):
         params = {'recipient_id': recipient_id, 'list_id': list_id}
         lists = self.sg.client.contactdb.lists
         try:
             response = lists._(list_id).recipients._(recipient_id).delete(query_params=params)
+
+            if response.status_code != 204 and response.status_code != 201:
+                error('Could not remove recipient {} from the mail list. SendGrid API responded with status code {}.'
+                      .format(recipient_id, response.status_code))
         except HTTPError:
             error('Could not remove recipient {} from the mail list. Error when calling SendGrid API')
 
-        if response.status_code != 204 and response.status_code != 201:
-            error('Could not remove recipient {} from the mail list. SendGrid API responded with status code {}.'
-                  .format(recipient_id, response.status_code))
+    def remove_applicant_from_list(self, application, list_id):
+
+        if application.sendgrid_id != "":
+            recipient_id = application.sendgrid_id
+            self._remove_recipient_from_list(recipient_id, list_id)
+
+        else:
+            # If it doesn't have a SG id, we still create and save the
+            # recipient but there's no need to remove him from anywhere
+            recipient_id = self._create_sendgrid_recipient(application)
+            application.sendgrid_id = recipient_id
+            application.save()

--- a/register/emails.py
+++ b/register/emails.py
@@ -56,14 +56,13 @@ class MailListManager:
 
     def add_applicant_to_list(self, application, list_id):
         # Test if application contains recipientid
-        if application.sendgrid_id != "":
-            recipient_id = application.sendgrid_id
-
-        else:
+        if not application.sendgrid_id:
             # If it doesn't, create recipient on sendgrid and store its id
             recipient_id = self._create_sendgrid_recipient(application)
             application.sendgrid_id = recipient_id
             application.save()
+
+        recipient_id = application.sendgrid_id
 
         # Add recipient to list
         self._add_recipient_to_list(recipient_id, list_id)
@@ -82,9 +81,8 @@ class MailListManager:
 
     def remove_applicant_from_list(self, application, list_id):
 
-        if application.sendgrid_id != "":
-            recipient_id = application.sendgrid_id
-            self._remove_recipient_from_list(recipient_id, list_id)
+        if application.sendgrid_id:
+            self._remove_recipient_from_list(application.sendgrid_id, list_id)
 
         else:
             # If it doesn't have a SG id, we still create and save the

--- a/register/emails.py
+++ b/register/emails.py
@@ -4,6 +4,7 @@ from logging import error
 import sendgrid
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
+from requests import HTTPError
 
 
 def sendgrid_send(recipients, subject, substitutions, template_id, from_email='HackUPC Team <contact@hackupc.com>'):
@@ -68,7 +69,10 @@ class MailListManager:
     def remove_recipient_from_list(self, recipient_id, list_id):
         params = {'recipient_id': recipient_id, 'list_id': list_id}
         lists = self.sg.client.contactdb.lists
-        response = lists._(list_id).recipients._(recipient_id).delete(query_params=params)
+        try:
+            response = lists._(list_id).recipients._(recipient_id).delete(query_params=params)
+        except HTTPError:
+            error('Could not remove recipient {} from the mail list. Error when calling SendGrid API')
 
         if response.status_code != 204 and response.status_code != 201:
             error('Could not remove recipient {} from the mail list. SendGrid API responded with status code {}.'

--- a/register/models.py
+++ b/register/models.py
@@ -141,7 +141,7 @@ class Application(models.Model):
             self.status = APP_CANCELLED
             self.save()
             m = MailListManager()
-            m.remove_recipient_from_list(self.sendgrid_id, m.WINTER_17_LIST_ID)
+            m.remove_applicant_from_list(self, m.WINTER_17_LIST_ID)
 
     def confirmation_url(self, request=None):
         return reverse('confirm_app', kwargs={'token': self.id}, request=request)


### PR DESCRIPTION
Solves #58. 

The problem was that the code to cancel attendance assumed that the SendGrid recipient for that application already existed (it would if the hacker first accepts and then cancels, for example). So when directly canceling we were calling SendGrid's API with an invalid (empty) recipient_id. That's what this PR fixes.