### PR TITLE
Add Others option to dietary requirements

### DIFF
--- a/register/forms.py
+++ b/register/forms.py
@@ -22,5 +22,6 @@ class HackerForm(forms.ModelForm):
             'gender': 'This is for demographic purposes. You can skip this question if you want',
             'graduation_year': 'What year have you graduated on or when will you graduate',
             'degree': 'What\'s your major?',
+            'diet': 'If you select Others, please drop us an email to let us know the details'
         }
         exclude = ['user', 'uuid']

--- a/register/models.py
+++ b/register/models.py
@@ -55,13 +55,17 @@ EDITIONS = [
 
 D_NONE = 'None'
 D_VEGETERIAN = 'Vegeterian'
+D_VEGAN = 'Vegan'
+D_NO_PORK = 'No pork'
 D_GLUTEN_FREE = 'Gluten-free'
 D_OTHER = 'Others'
 
 DIETS = [
     (D_NONE, 'No requirements'),
-    (D_VEGETERIAN, 'Vegeterian/Vegan'),
-    (D_GLUTEN_FREE, 'Gluten free'),
+    (D_VEGETERIAN, 'Vegeterian'),
+    (D_VEGAN, 'Vegan'),
+    (D_NO_PORK, 'No pork'),
+    (D_GLUTEN_FREE, 'Gluten-free'),
     (D_OTHER, 'Others')
 ]
 

--- a/register/models.py
+++ b/register/models.py
@@ -56,11 +56,13 @@ EDITIONS = [
 D_NONE = 'None'
 D_VEGETERIAN = 'Vegeterian'
 D_GLUTEN_FREE = 'Gluten-free'
+D_OTHER = 'Others'
 
 DIETS = [
-    (D_NONE, 'None'),
+    (D_NONE, 'No requirements'),
     (D_VEGETERIAN, 'Vegeterian/Vegan'),
-    (D_GLUTEN_FREE, 'Gluten free')
+    (D_GLUTEN_FREE, 'Gluten free'),
+    (D_OTHER, 'Others')
 ]
 
 TSHIRT_SIZES = [(size, size) for size in ('XS S M L XL'.split(' '))]


### PR DESCRIPTION
Add an `Others` option to the dietary requirements. Partially solves #112. A free-text input for special needs would be better, but this is better than nothing, for now.