### PR TITLE
Make PROD_MODE check for a non-false value

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -25,7 +25,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.environ.get('SECRET', ')6+vf9(1tihg@u8!+(0abk+y*#$3r$(-d=g5qhm@1&lo4pays&')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = not os.environ.get('PROD_MODE', None)
+DEBUG = os.environ.get('PROD_MODE', "false").lower() == "false"
 ALLOWED_HOSTS = ['localhost', '127.0.0.1', '0.0.0.0']
 
 # Application definition


### PR DESCRIPTION
This also defaults PROD_MODE to "false", which shouldn't affect how
people are currently using the environment variable.

It would ideally check for `!= "true"` but I'm not sure how others are
currently use the environment variable.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines  https://github.com/HackAssistant/registration/blob/master/.github/CONTRIBUTING.md
-->





## Some questions
- [x] I have read the contributing guidelines
- [x] I abide by this repository Code of Conduct
- [x] I understand that my PR won't be merged until Travis gives a "green light"

<!--You can leave this and check them once the PR has been created.-->

