### PR TITLE
Add 'already accepted' team message

### DIFF
--- a/teams/templates/team.html
+++ b/teams/templates/team.html
@@ -41,8 +41,8 @@
             </button>
         </form>
     {% elif application.answered_invite or application.is_invited %}
-
-
+        <p>You've already been accepted, so you don't need to join a team.</p>
+        <p>Please email us if your (future) teammates haven't been accepted, and we'll put you in their team.</p>
     {% elif not h_app_closed and not team %}
         <p>Do you have a team already? Join it below. Otherwise you can create a new team. </p>
         <form action="" method="post" class="form">


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines  https://github.com/HackAssistant/registration/blob/master/.github/CONTRIBUTING.md
-->

## What this PR does / Why we need it
Currently if you have been accepted and click on the team tab, the team tab will just be empty. This pull request fixes that.

## Special notes for your reviewer (optional)

Got an email from a HackUPC person who's coming to Hack the Burgh, and they were very confused about the blank page ;)

## Some questions
- [x] I have read the contributing guidelines
- [x]  I abide by this repository Code of Conduct
- [x] I understand that my PR won't be merged until Travis gives a "green light"

<!--You can leave this and check them once the PR has been created.-->

