### PR TITLE
Fix tab volunteers on checkin

### DIFF
--- a/checkin/views.py
+++ b/checkin/views.py
@@ -33,6 +33,8 @@ class CheckInList(IsVolunteerMixin, TabsViewMixin, SingleTableMixin, FilterView)
     table_pagination = {'per_page': 50}
 
     def get_current_tabs(self):
+        if self.request.user.is_volunteer_accepted:
+            return None
         return hacker_tabs(self.request.user)
 
     def get_queryset(self):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines  https://github.com/HackAssistant/registration/blob/master/.github/CONTRIBUTING.md
-->

## Patch Notes
<!-- Specify in short lines if you are fixing bugs, improving software or implementing news to Hackassistant-->
There was an issue with the tabs display that showed items that were not allowed to volunteers. The solutions was deleting the tabs because it is not necessary for the volunteers to see it.

## Which issue(s) this PR fixes (optional) 
<!-- Fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged)-->
<!-- References #<issue number>(, references #<issue_number>, ...) format, will reference the issue(s) when PR gets merged but won't close it)-->
Fixes #
References #

## Additional Notes (optional)
<!-- Do you want to add anything else? We :heart: to hear your opinions!-->


## Some questions
- [x] I have read the contributing guidelines
- [x] I abide by this repository Code of Conduct
- [x] I understand that my PR won't be merged until GitHub gives a "green light"

<!-- You can leave this and check them once the PR has been created.-->
<!-- Please check them before merging, thank you so much for your help!-->
